### PR TITLE
remove extends file from App namespace

### DIFF
--- a/src/Ivliev/Imagefly/ImageflyController.php
+++ b/src/Ivliev/Imagefly/ImageflyController.php
@@ -1,10 +1,15 @@
 <?php
 namespace Ivliev\Imagefly;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
 
-class ImageflyController extends Controller
+class ImageflyController extends BaseController
 {
+
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 
     /*
      * |--------------------------------------------------------------------------


### PR DESCRIPTION
When project have difrent namespace than `App` `ImagaflyController` cannot find `App\Http\Controllers\Controller`
This is fix for this bug
